### PR TITLE
Move Sessions Features Below User Features

### DIFF
--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -21,49 +21,6 @@ models:
       edge_sources:
         - from: inputs/rsPages
 
-  # Remove the section below, if you don't want to generate a feature table
-  - name: shopify_session_features
-    model_type: feature_table_model
-    model_spec:
-      validity_time: 24h # 1 day
-      entity_key: session
-      vars:
-        - entity_var:
-            name: session_end_time
-            select: max(timestamp)
-            from: inputs/rsPages
-
-        - entity_var:
-            name: session_start_time
-            select: min(timestamp)
-            from: inputs/rsPages
-
-        - entity_var:
-            name: session_length
-            select: TIMESTAMPDIFF(SECOND, session_start_time, session_end_time)
-            dependencies:
-                - session_end_time
-                - session_start_time
-
-        - entity_var:
-            name: user_id
-            select: max(user_id)
-            where: user_id is not null
-            from: inputs/rsPages
-
-        - entity_var:
-            name: anonymous_id
-            select: max(anonymous_id)
-            where: anonymous_id is not null
-            from: inputs/rsPages
-
-      features:
-        - session_end_time
-        - session_start_time
-        - session_length
-        - user_id
-        - anonymous_id
-
   - name: shopify_user_features
     model_type: feature_table_model
     model_spec:
@@ -559,3 +516,47 @@ models:
         - net_amt_spent_in_past
         - gross_amt_spent_in_past
         - items_purchased_ever
+
+
+  # Remove the section below, if you don't want to generate a feature table
+  - name: shopify_session_features
+    model_type: feature_table_model
+    model_spec:
+      validity_time: 24h # 1 day
+      entity_key: session
+      vars:
+        - entity_var:
+            name: session_end_time
+            select: max(timestamp)
+            from: inputs/rsPages
+
+        - entity_var:
+            name: session_start_time
+            select: min(timestamp)
+            from: inputs/rsPages
+
+        - entity_var:
+            name: session_length
+            select: TIMESTAMPDIFF(SECOND, session_start_time, session_end_time)
+            dependencies:
+                - session_end_time
+                - session_start_time
+
+        - entity_var:
+            name: user_id
+            select: max(user_id)
+            where: user_id is not null
+            from: inputs/rsPages
+
+        - entity_var:
+            name: anonymous_id
+            select: max(anonymous_id)
+            where: anonymous_id is not null
+            from: inputs/rsPages
+
+      features:
+        - session_end_time
+        - session_start_time
+        - session_length
+        - user_id
+        - anonymous_id


### PR DESCRIPTION
I moved the session features model below the user features model so the UI would show user features before the session features

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
